### PR TITLE
Reverts #34053 Floor tile dragging over plating and reinforced flooring 

### DIFF
--- a/code/game/objects/items/stacks/tiles/tiles.dm
+++ b/code/game/objects/items/stacks/tiles/tiles.dm
@@ -99,11 +99,6 @@
 				QDEL_NULL(active) //otherwise remove the draggable screen
 
 /obj/item/stack/tile/drag_use(mob/user, turf/T)
-	if(T.canBuildFloortile(src.type) && istype(T,/turf/simulated/floor))
-		var/turf/simulated/floor/F = T
-		F.make_tiled_floor(src)
-		playsound(T, 'sound/weapons/Genhit.ogg', 25, 1)
-		return
 	if(T.canBuildPlating() == BUILD_SUCCESS) //This deletes lattices, only necessary for BUILD_SUCCESS
 		var/L = locate(/obj/structure/lattice) in T
 		if(!L)


### PR DESCRIPTION
doing this midround because of how much it pisses me off 

## What this does
reverts the ability to drag-place floor tiles over plating

## Why it's good
makes it awful trying to drag-place plating down, because you end up putting down floor tiles as well

## How it was tested
it wasnt 

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscdel: Removed quick-drag-placing for floor tiles over platings.
